### PR TITLE
Name changes and make IDs actually optional

### DIFF
--- a/steps/create-annotation/step.py
+++ b/steps/create-annotation/step.py
@@ -14,16 +14,21 @@ payload = {
   'time': round(time.time() * 1000)
 }
 
-# these should default to a false-y 0 if not overridden by user
-if relay.get(D.dashboardID):
-  payload['dashboardID'] = int(relay.get(D.dashboardID))
-
-if relay.get(D.panelID):
-  payload['panelID'] = int(relay.get(D.panelID))
+try:
+  dashboardID = int(relay.get(D.dashboardID))
+  payload['dashboardID'] = dashboardID
+except requests.exceptions.HTTPError:
+  pass
 
 try:
-  labels = relay.get(D.labels)
-  payload['labels'] = labels
+  panelID = int(relay.get(D.panelID))
+  payload["panelID"] = panelID
+except requests.exceptions.HTTPError:
+  pass
+
+try:
+  tags = relay.get(D.tags)
+  payload['tags'] = tags
 except requests.exceptions.HTTPError:
   pass
 

--- a/steps/create-annotation/step.yaml
+++ b/steps/create-annotation/step.yaml
@@ -63,10 +63,10 @@ schemas:
       text:
         type: string
         description: The text of the annotation
-      dashboardId:
+      dashboardID:
         type: string
         description: The optional numeric ID of the dashboard to update 
-      panelId:
+      panelID:
         type: string
         description: The optional numeric ID of the dashboard panel to annotate
       tags:


### PR DESCRIPTION
dashboardId > dashboardID and panelId > panelID in metadata to match what Python script expects
labels > tags in Python script to match what Grafana API expects
Catch the exceptions generated by Relay when leaving out panelID or dashboardID so that they are actually optional